### PR TITLE
Remove colon from title on movies index

### DIFF
--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -5,7 +5,7 @@
     </div>
     <div class="row mx-0 mt-4">
       <div class="col-9">
-        <h1>Films out now:</h1>
+        <h1>Films out now</h1>
         <div class="movies-index">
           <% @movies.each do |movie| %>
             <%# if movie.movie_shows.empty? == false %>


### PR DESCRIPTION
Quick fix to remove the colon from the title on the movies index (so it is consisent with other pages' titles)